### PR TITLE
Generate and upload AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,48 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: trusty
+
+before_install:
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get update -qq
+
+install:
+  - sudo apt-get -y install g++-4.9 cmake pkg-config libgoogle-glog-dev libssl-dev libevent-dev libjsoncpp-dev
+
+script:
+  - cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
+  - make -j$(nproc)
+  - mkdir -p appdir/usr/bin/ ; cp -r bin/* appdir/usr/bin/
+  - mkdir -p appdir/usr/share/applications/ ; cp shadowsocksr.desktop appdir/usr/share/applications/
+  - mkdir -p appdir/usr/share/icons/hicolor/512x512/apps/ ; wget -c "https://github.com/shadowsocks/shadowsocks-qt5/blob/0e600008bc03687aafd0ff919632ce208180e25b/src/icons/shadowsocks-qt5.png?raw=true" -O appdir/usr/share/icons/hicolor/512x512/apps/shadowsocksr.png # FIXME 请把图标放在这里
+  - find appdir/
+  - wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+  - chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - export VERSION=$(git rev-parse --short HEAD) # linuxdeployqt uses this for naming the file
+  - |
+    ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -verbose=2 -appimage \
+    -executable=libEventLoop.so \
+    -executable=libSocketNode.so \
+    -executable=libSocket.so \
+    -executable=plugin/libPortTunnel.so \
+    -executable=plugin/libSocketConnector.so \
+    -executable=plugin/libSocksClient.so \
+    -executable=plugin/libSocksServer.so \
+    -executable=plugin/libSSRLocal.so \
+    -executable=plugin/ \
+    -executable=plugin/SSR/libAuthChain.so \
+    -executable=plugin/SSR/libHTTPSimple.so \
+    -executable=plugin/SSR/libTLSTicketAuth.so 
+    
+after_success:
+  - find appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+  - # curl --upload-file ShadowSocksr*.AppImage https://transfer.sh/ShadowSocksr-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+  - bash upload.sh ShadowSocksr*.AppImage*
+  
+branches:
+  except:
+    - # Do not build tags that we create when we upload to GitHub Releases
+    - /^(?i:continuous)/

--- a/Project/Plugin/SSR/SSRProtocol/AuthChain/AuthChainLocal.cpp
+++ b/Project/Plugin/SSR/SSRProtocol/AuthChain/AuthChainLocal.cpp
@@ -43,8 +43,7 @@ CAuthHeader CAuthChainLocal::PackAuthData()
     g_AuthChainSession->SetConnectionID(ConnectionID + 1);
     g_AuthChainSession->UnLockSession();
 
-    //TODO Remuse overhead GetOverHead()
-    AuthHeader.ClientInfo.SetInfo(ClientID, ConnectionID, 4);
+    AuthHeader.ClientInfo.SetInfo(ClientID, ConnectionID, m_OverHead);
 
     AuthHeader.UserID = m_UserID ^ * (u_int *)(m_LastClientHash + 8);
 

--- a/include/Plugin/SSR/Utils/Encryptor.h
+++ b/include/Plugin/SSR/Utils/Encryptor.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include <cstring>
+#include <cstdint>
 #include <openssl/md5.h>
 #include <openssl/evp.h>
 

--- a/shadowsocksr.desktop
+++ b/shadowsocksr.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=ShadowSocksr
+GenericName=ShadowSocks Client
+GenericName[zh_CN]=影梭客户端
+Exec=ShadowSocksr
+Icon=shadowsocksr
+Terminal=true
+Type=Application
+Categories=Network;
+Keywords=ss;socks;shadowsocks;


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to your GitHub Releases page.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Applications packaged as an AppImage can run on many distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions
- Can be listed in the [AppImageHub](https://appimage.github.io/apps) central directory of available AppImages
- Can double as a self-extracting compressed archive with the `--appimage-extract` parameter
- No repositories needed. Suitable/optimized for air-gapped (offline) machines

[Here is an overview](https://appimage.github.io/apps) of projects that are already distributing upstream-provided, official AppImages.

__PLEASE NOTE:__ For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so. Also, You need to set up `GITHUB_TOKEN` in Travis CI for this to work; please see https://github.com/probonopd/uploadtool.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.